### PR TITLE
Feature/communal items

### DIFF
--- a/char-sheet/src/components/CampaignModal.tsx
+++ b/char-sheet/src/components/CampaignModal.tsx
@@ -98,7 +98,7 @@ function CampaignModal({ open, close, token, sheetId, rules, setActiveCampaignId
 
     function addItem(equipment: Equipment) {
         if (!editCampaign) return
-        const item: SheetEquipment = { name: equipment.name }
+        const item: SheetEquipment = { name: equipment.name, uid: uuidv4() }
         if (equipment.custom) item.custom = true
         if (equipment.stack) { item.count = 1; item.stack = equipment.stack }
         setEditCampaign({ ...editCampaign, items: [...editCampaign.items, item] })

--- a/char-sheet/src/components/CampaignModal.tsx
+++ b/char-sheet/src/components/CampaignModal.tsx
@@ -15,6 +15,10 @@ import { alertError, alertSuccess } from '../lib/alerts'
 import { timeSince } from '../lib/util'
 import { v4 as uuidv4 } from 'uuid'
 
+function campaignInviteUrl(campaignId: string): string {
+    return `${window.location.origin}${window.location.pathname}?campaign=${encodeURIComponent(campaignId)}`
+}
+
 type View = 'list' | 'edit'
 
 function CampaignModal({ open, close, token, sheetId, rules, setActiveCampaignId }: {
@@ -37,10 +41,10 @@ function CampaignModal({ open, close, token, sheetId, rules, setActiveCampaignId
     const userEmail = token ? server.parseToken(token) : null
 
     useEffect(() => {
-        if (open) {
+        if (open && token) {
             setCampaigns(null)
             setView('list')
-            server.listCampaigns()
+            server.listCampaigns(token)
                 .then(c => setCampaigns(c ?? []))
                 .catch(e => alertError(`Error loading campaigns: ${e.message}`))
         }
@@ -49,8 +53,9 @@ function CampaignModal({ open, close, token, sheetId, rules, setActiveCampaignId
     if (!open || !rules) return null
 
     function reloadList() {
+        if (!token) return
         setCampaigns(null)
-        server.listCampaigns()
+        server.listCampaigns(token)
             .then(c => setCampaigns(c ?? []))
             .catch(e => alertError(`Error reloading campaigns: ${e.message}`))
     }
@@ -225,7 +230,18 @@ function CampaignModal({ open, close, token, sheetId, rules, setActiveCampaignId
                                         </p>
                                     </div>
                                 </button>
-                                {isOwner && (
+                                {isOwner && (<>
+                                    <button
+                                        className='btn btn-outline btn-square'
+                                        onClick={() => {
+                                            navigator.clipboard.writeText(campaignInviteUrl(c.id))
+                                                .then(() => alertSuccess('Invite link copied'))
+                                                .catch(() => alertError('Could not copy to clipboard'))
+                                        }}
+                                        title='Copy invite link'
+                                    >
+                                        ⎘
+                                    </button>
                                     <button
                                         className='btn btn-outline btn-square'
                                         onClick={() => openEdit(c)}
@@ -233,7 +249,7 @@ function CampaignModal({ open, close, token, sheetId, rules, setActiveCampaignId
                                     >
                                         ✎
                                     </button>
-                                )}
+                                </>)}
                             </div>
                         )
                     })}

--- a/char-sheet/src/components/CampaignModal.tsx
+++ b/char-sheet/src/components/CampaignModal.tsx
@@ -1,0 +1,240 @@
+// External imports
+import { useEffect, useState } from 'react'
+
+// Components
+import ActionModal from './ActionModal'
+import IconButton from './IconButton'
+import LoadingSpinner from './LoadingSpinner'
+import EquipmentSelectModal from './EquipmentSelectModal'
+import { ImCross } from 'react-icons/im'
+
+// Internal imports
+import { Campaign, Equipment, Rules, SheetEquipment } from '../lib/rules'
+import server, { ServerItem } from '../lib/server'
+import { alertError, alertSuccess } from '../lib/alerts'
+import { timeSince } from '../lib/util'
+import { v4 as uuidv4 } from 'uuid'
+
+type View = 'list' | 'edit'
+
+function CampaignModal({ open, close, token, sheetId, rules, setActiveCampaignId }: {
+    open: boolean,
+    close(): void,
+    token: string | null,
+    sheetId: string | null,
+    rules: Rules | undefined,
+    setActiveCampaignId(id: string | null): void,
+}): JSX.Element | null {
+
+    const [campaigns, setCampaigns] = useState<ServerItem[] | null>(null)
+    const [view, setView] = useState<View>('list')
+    const [editId, setEditId] = useState<string>('')
+    const [editTitle, setEditTitle] = useState<string>('')
+    const [editCampaign, setEditCampaign] = useState<Campaign | null>(null)
+    const [saving, setSaving] = useState(false)
+    const [itemModalOpen, setItemModalOpen] = useState(false)
+
+    const userEmail = token ? server.parseToken(token) : null
+
+    useEffect(() => {
+        if (open) {
+            setCampaigns(null)
+            setView('list')
+            server.listCampaigns()
+                .then(c => setCampaigns(c ?? []))
+                .catch(e => alertError(`Error loading campaigns: ${e.message}`))
+        }
+    }, [open])
+
+    if (!open || !rules) return null
+
+    function reloadList() {
+        setCampaigns(null)
+        server.listCampaigns()
+            .then(c => setCampaigns(c ?? []))
+            .catch(e => alertError(`Error reloading campaigns: ${e.message}`))
+    }
+
+    function openCreate() {
+        setEditId(uuidv4())
+        setEditTitle('New Campaign')
+        setEditCampaign({ type: 'campaign', members: [], items: [] })
+        setView('edit')
+    }
+
+    function openEdit(item: ServerItem) {
+        setEditId(item.id)
+        setEditTitle(item.title)
+        const content = item.content as Campaign
+        setEditCampaign({ ...content, members: content.members ?? [], items: content.items ?? [] })
+        setView('edit')
+    }
+
+    function activateCampaign(id: string) {
+        setActiveCampaignId(id)
+        close()
+    }
+
+    function deactivateCampaign() {
+        setActiveCampaignId(null)
+        close()
+    }
+
+    async function joinCampaign(campaignId: string) {
+        if (!token || !sheetId) return
+        try {
+            await server.joinCampaign(token, campaignId, sheetId)
+            alertSuccess('Joined campaign')
+            activateCampaign(campaignId)
+        } catch (e: any) {
+            alertError(`Error joining campaign: ${e.message}`)
+        }
+    }
+
+    function addItem(equipment: Equipment) {
+        if (!editCampaign) return
+        const item: SheetEquipment = { name: equipment.name }
+        if (equipment.custom) item.custom = true
+        if (equipment.stack) { item.count = 1; item.stack = equipment.stack }
+        setEditCampaign({ ...editCampaign, items: [...editCampaign.items, item] })
+    }
+
+    function removeItem(index: number) {
+        if (!editCampaign) return
+        setEditCampaign({ ...editCampaign, items: editCampaign.items.filter((_, i) => i !== index) })
+    }
+
+    async function save() {
+        if (!editCampaign || !editTitle.trim() || !token) return
+        setSaving(true)
+        try {
+            await server.writeCampaign(token, editId, editTitle.trim(), editCampaign)
+            alertSuccess('Campaign saved')
+            reloadList()
+            setView('list')
+        } catch (e: any) {
+            alertError(`Error saving campaign: ${e.message}`)
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    if (view === 'edit' && editCampaign) {
+        return (
+            <ActionModal
+                open={open}
+                close={() => setView('list')}
+                title={editTitle || 'New Campaign'}
+                actions={[
+                    {
+                        name: saving ? 'Saving...' : 'Save',
+                        type: 'primary',
+                        disabled: saving || !editTitle.trim(),
+                        callback: save,
+                        stayOpen: true,
+                    }
+                ]}
+            >
+                <div className='flex flex-col gap-3 w-full'>
+                    <input
+                        className='input input-bordered w-full'
+                        value={editTitle}
+                        onChange={e => setEditTitle(e.target.value)}
+                        placeholder='Campaign name'
+                    />
+
+                    <div>
+                        <h3 className='font-bold mb-1'>Shared Items</h3>
+                        {editCampaign.items.length === 0 && (
+                            <p className='text-sm opacity-60'>No items.</p>
+                        )}
+                        {editCampaign.items.map((item, i) => (
+                            <div key={i} className='flex items-center gap-2 mb-1'>
+                                <span className='grow text-sm'>{item.name}{item.stack ? ` ×${item.count ?? 0}` : ''}</span>
+                                <button
+                                    className='btn btn-xs btn-ghost btn-square text-error'
+                                    onClick={() => removeItem(i)}
+                                >
+                                    <ImCross size={10} />
+                                </button>
+                            </div>
+                        ))}
+                        <div className='flex justify-center mt-2'>
+                            <IconButton icon='plus' enabled={true} onClick={() => setItemModalOpen(true)} />
+                        </div>
+                    </div>
+                </div>
+
+                <EquipmentSelectModal
+                    open={itemModalOpen}
+                    close={() => setItemModalOpen(false)}
+                    enabled={true}
+                    equipment={itemModalOpen ? rules.equipment : []}
+                    addEquipment={addItem}
+                />
+            </ActionModal>
+        )
+    }
+
+    return (
+        <ActionModal
+            open={open}
+            close={close}
+            title='Campaigns'
+            actions={token ? [
+                {
+                    name: '+ New Campaign',
+                    type: 'primary',
+                    callback: openCreate,
+                    stayOpen: true,
+                },
+                {
+                    name: 'Leave Campaign',
+                    callback: deactivateCampaign,
+                },
+            ] : []}
+        >
+            {campaigns === null ? (
+                <LoadingSpinner />
+            ) : campaigns.length === 0 ? (
+                <p className='py-2'>No campaigns yet.</p>
+            ) : (
+                <div className='flex flex-col gap-2 py-2 w-full max-w-sm'>
+                    {campaigns.map(c => {
+                        const isMember = sheetId && (c.content as Campaign)?.members?.includes(sheetId)
+                        const isOwner = c.owner === userEmail
+                        return (
+                            <div key={c.id} className='flex gap-2 w-full'>
+                                <button
+                                    className='btn btn-primary p-0 grow'
+                                    onClick={() => isMember ? activateCampaign(c.id) : joinCampaign(c.id)}
+                                >
+                                    <div>
+                                        <h2 className='font-bold text-lg normal-case'>{c.title}</h2>
+                                        <p className='text-xs normal-case opacity-75'>
+                                            DM: {c.owner} · {timeSince(new Date(c.time))} ago · {(c.content as Campaign)?.members?.length ?? 0} members
+                                        </p>
+                                        <p className='text-xs normal-case opacity-75'>
+                                            {isMember ? 'Active — click to switch' : 'Click to join'}
+                                        </p>
+                                    </div>
+                                </button>
+                                {isOwner && (
+                                    <button
+                                        className='btn btn-outline btn-square'
+                                        onClick={() => openEdit(c)}
+                                        title='Edit campaign'
+                                    >
+                                        ✎
+                                    </button>
+                                )}
+                            </div>
+                        )
+                    })}
+                </div>
+            )}
+        </ActionModal>
+    )
+}
+
+export default CampaignModal

--- a/char-sheet/src/components/CampaignModal.tsx
+++ b/char-sheet/src/components/CampaignModal.tsx
@@ -142,6 +142,12 @@ function CampaignModal({ open, close, token, sheetId, rules, setActiveCampaignId
                         onChange={e => setEditTitle(e.target.value)}
                         placeholder='Campaign name'
                     />
+                    <input
+                        className='input input-bordered w-full'
+                        value={editCampaign.stashName ?? ''}
+                        onChange={e => setEditCampaign({ ...editCampaign, stashName: e.target.value })}
+                        placeholder='Communal stash name (default: Communal)'
+                    />
 
                     <div>
                         <h3 className='font-bold mb-1'>Shared Items</h3>

--- a/char-sheet/src/components/CampaignModal.tsx
+++ b/char-sheet/src/components/CampaignModal.tsx
@@ -194,10 +194,10 @@ function CampaignModal({ open, close, token, sheetId, rules, setActiveCampaignId
                     callback: openCreate,
                     stayOpen: true,
                 },
-                {
+                ...(sheetId && campaigns?.some(c => (c.content as Campaign)?.members?.includes(sheetId)) ? [{
                     name: 'Leave Campaign',
                     callback: deactivateCampaign,
-                },
+                }] : []),
             ] : []}
         >
             {campaigns === null ? (

--- a/char-sheet/src/components/CampaignPanel.tsx
+++ b/char-sheet/src/components/CampaignPanel.tsx
@@ -14,6 +14,7 @@ import server, { ServerItem } from '../lib/server'
 import { alertError } from '../lib/alerts'
 import { View } from '../lib/objectservice'
 import { listUtil } from '../lib/util'
+import { v4 as uuidv4 } from 'uuid'
 
 const POLL_INTERVAL_MS = 5000
 
@@ -62,15 +63,41 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
         const unsub = equipmentView.view('communal').subscribe('', () => {
             if (selfWriting.current) { selfWriting.current = false; return }
             if (cancelled) return
-            const items: SheetEquipment[] = (equipmentView.read('communal') ?? []).filter(Boolean)
+            const remaining: SheetEquipment[] = (equipmentView.read('communal') ?? []).filter(Boolean)
             setCampaign(prev => {
                 if (!prev) return prev
-                const updated = { ...prev, items }
-                if (token) {
-                    server.writeCampaign(token, campaignId, metaRef.current?.title ?? '', updated)
-                        .catch(e => alertError(`Error syncing campaign: ${e.message}`))
+                if (!token) return { ...prev, items: remaining }
+                // Find the removed item by uid if available, else by name
+                const remainingUids = new Set(remaining.map(r => r.uid).filter(Boolean))
+                const remainingNames = [...remaining]
+                let removedUid: string | null = null
+                let removedName: string | null = null
+                for (const item of prev.items) {
+                    if (item.uid) {
+                        if (!remainingUids.has(item.uid)) { removedUid = item.uid; break }
+                    } else {
+                        const idx = remainingNames.findIndex(r => r.name === item.name)
+                        if (idx === -1) { removedName = item.name; break }
+                        remainingNames.splice(idx, 1)
+                    }
                 }
-                return updated
+                if (!removedUid && !removedName) return prev
+                const uidToRemove = removedUid
+                const nameToRemove = removedName
+                server.patchCampaign(token, campaignId, current => {
+                    if (uidToRemove) {
+                        return { ...current, items: current.items.filter(item => item.uid !== uidToRemove) }
+                    }
+                    const i = current.items.findIndex(item => item.name === nameToRemove)
+                    if (i === -1) return current
+                    return { ...current, items: current.items.filter((_, idx) => idx !== i) }
+                }).then(patched => {
+                    if (cancelled) return
+                    selfWriting.current = true
+                    setCampaign(patched)
+                    equipmentView.publish('communal', patched.items)
+                }).catch(e => alertError(`Error syncing campaign: ${e.message}`))
+                return { ...prev, items: remaining }
             })
         })
 
@@ -91,32 +118,58 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
         return name
     }
 
-    function saveUpdated(updated: Campaign) {
-        setCampaign(updated)
+    function applyPatch(
+        optimistic: Campaign,
+        patch: (c: Campaign) => Campaign,
+    ) {
+        setCampaign(optimistic)
         selfWriting.current = true
-        equipmentView.publish('communal', updated.items)
-        if (token) {
-            server.writeCampaign(token, campaignId, metaRef.current?.title ?? '', updated)
-                .catch(e => alertError(`Error updating campaign: ${e.message}`))
-        }
+        equipmentView.publish('communal', optimistic.items)
+        if (!token) return
+        server.patchCampaign(token, campaignId, patch)
+            .then(patched => {
+                // Reconcile: server state may differ if another user wrote concurrently
+                if (JSON.stringify(patched.items) !== JSON.stringify(optimistic.items)) {
+                    selfWriting.current = true
+                    setCampaign(patched)
+                    equipmentView.publish('communal', patched.items)
+                }
+            })
+            .catch(e => alertError(`Error updating campaign: ${e.message}`))
     }
 
     function addItem(equipment: Equipment) {
         if (!campaign) return
-        const item: SheetEquipment = { name: equipment.name }
-        if (equipment.custom) item.custom = true
-        if (equipment.stack) { item.count = 1; item.stack = equipment.stack }
-        saveUpdated({ ...campaign, items: [...campaign.items, item] })
+        const newItem: SheetEquipment = { name: equipment.name, uid: uuidv4() }
+        if (equipment.custom) newItem.custom = true
+        if (equipment.stack) { newItem.count = 1; newItem.stack = equipment.stack }
+        applyPatch(
+            { ...campaign, items: [...campaign.items, newItem] },
+            c => ({ ...c, items: [...c.items, newItem] }),
+        )
     }
 
     function removeItem(index: number) {
         if (!campaign) return
-        saveUpdated({ ...campaign, items: campaign.items.filter((_, i) => i !== index) })
+        const uid = campaign.items[index]?.uid
+        applyPatch(
+            { ...campaign, items: campaign.items.filter((_, i) => i !== index) },
+            c => ({ ...c, items: uid ? c.items.filter(item => item.uid !== uid) : c.items.filter((_, i) => i !== index) }),
+        )
     }
 
     function setItemCount(index: number, count: number) {
         if (!campaign) return
-        saveUpdated({ ...campaign, items: campaign.items.map((item, i) => i === index ? { ...item, count } : item) })
+        const uid = campaign.items[index]?.uid
+        applyPatch(
+            { ...campaign, items: campaign.items.map((item, i) => i === index ? { ...item, count } : item) },
+            c => ({
+                ...c,
+                items: uid
+                    ? c.items.map(item => item.uid === uid ? { ...item, count } : item)
+                    : c.items.map((item, i) => i === index ? { ...item, count } : item),
+            }),
+        )
     }
 
     // Drop from local equipment container into communal
@@ -126,7 +179,12 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
         const dropped = sourceItems[dragItem.index]
         if (!dropped) return
         equipmentView.publish(dragItem.container, listUtil.delete(sourceItems, dragItem.index))
-        saveUpdated({ ...campaign, items: [...campaign.items, { ...dropped }] })
+        // Assign a uid if the item doesn't have one (came from local sheet which predates uid)
+        const droppedCopy = { ...dropped, uid: dropped.uid ?? uuidv4() }
+        applyPatch(
+            { ...campaign, items: [...campaign.items, droppedCopy] },
+            c => ({ ...c, items: [...c.items, droppedCopy] }),
+        )
     }
 
     const title = campaign?.stashName?.trim() || 'Communal'
@@ -160,7 +218,7 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
                         <tr
                             className='hover tooltip tooltip-left w-full'
                             data-tip={lookupDescription(item.name)}
-                            key={i}
+                            key={item.uid ?? i}
                         >
                             <td className='w-full text-left'>
                                 <DragSource type='communal' item={{ index: i }} enabled={canEdit}>

--- a/char-sheet/src/components/CampaignPanel.tsx
+++ b/char-sheet/src/components/CampaignPanel.tsx
@@ -127,12 +127,12 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
         saveUpdated({ ...campaign, items: [...campaign.items, { ...dropped }] })
     }
 
-    const title = 'Communal'
+    const title = campaign?.stashName?.trim() || 'Communal'
 
     if (notFound) {
         return (
             <table className="table table-compact w-80">
-                <thead><tr><th>Items: {title}</th></tr></thead>
+                <thead><tr><th>Items: Communal</th></tr></thead>
                 <tbody><tr><td className='text-error'>Campaign not found.</td></tr></tbody>
             </table>
         )
@@ -141,7 +141,7 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
     if (!campaign) {
         return (
             <table className="table table-compact w-80">
-                <thead><tr><th>Items: {title}</th></tr></thead>
+                <thead><tr><th>Items: Communal</th></tr></thead>
                 <tbody><tr><td>Loading...</td></tr></tbody>
             </table>
         )

--- a/char-sheet/src/components/CampaignPanel.tsx
+++ b/char-sheet/src/components/CampaignPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 // Components
 import IconButton from './IconButton'
 import EquipmentSelectModal from './EquipmentSelectModal'
+import ActionModal from './ActionModal'
 import PointEntryBox from './PointEntryBox'
 import { DragSource } from './dnd/DragSource'
 import { DropTarget } from './dnd/DropTarget'
@@ -18,6 +19,13 @@ import { v4 as uuidv4 } from 'uuid'
 
 const POLL_INTERVAL_MS = 5000
 
+interface PendingTransfer {
+    item: SheetEquipment,
+    direction: 'toLocal' | 'toCommunal',
+    sourceContainer?: string,
+    quantity: number,
+}
+
 function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
     campaignId: string,
     sheetId: string | null,
@@ -30,6 +38,7 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
     const [meta, setMeta] = useState<{ title: string, owner: string } | null>(null)
     const [modalOpen, setModalOpen] = useState(false)
     const [notFound, setNotFound] = useState(false)
+    const [pendingTransfer, setPendingTransfer] = useState<PendingTransfer | null>(null)
     const selfWriting = useRef(false)
     const metaRef = useRef<{ title: string, owner: string } | null>(null)
 
@@ -60,35 +69,44 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
         }
 
         // Watch for EquipmentTable dropping communal items into local containers
+        // (non-stackable only — stackable transfers go through confirmTransfer)
         const unsub = equipmentView.view('communal').subscribe('', () => {
             if (selfWriting.current) { selfWriting.current = false; return }
             if (cancelled) return
             const remaining: SheetEquipment[] = (equipmentView.read('communal') ?? []).filter(Boolean)
             setCampaign(prev => {
                 if (!prev) return prev
-                if (!token) return { ...prev, items: remaining }
                 // Find the removed item by uid if available, else by name
                 const remainingUids = new Set(remaining.map(r => r.uid).filter(Boolean))
                 const remainingNames = [...remaining]
-                let removedUid: string | null = null
-                let removedName: string | null = null
+                let removedItem: SheetEquipment | null = null
                 for (const item of prev.items) {
                     if (item.uid) {
-                        if (!remainingUids.has(item.uid)) { removedUid = item.uid; break }
+                        if (!remainingUids.has(item.uid)) { removedItem = item; break }
                     } else {
                         const idx = remainingNames.findIndex(r => r.name === item.name)
-                        if (idx === -1) { removedName = item.name; break }
+                        if (idx === -1) { removedItem = item; break }
                         remainingNames.splice(idx, 1)
                     }
                 }
-                if (!removedUid && !removedName) return prev
-                const uidToRemove = removedUid
-                const nameToRemove = removedName
+                if (!removedItem) return prev
+                if (removedItem.stack && (removedItem.count ?? 0) > 1 && token) {
+                    // Stackable: restore communal view and show quantity picker instead
+                    selfWriting.current = true
+                    equipmentView.publish('communal', prev.items)
+                    setPendingTransfer({
+                        item: removedItem,
+                        direction: 'toLocal',
+                        quantity: 1,
+                    })
+                    return prev
+                }
+                if (!token) return { ...prev, items: remaining }
+                const uid = removedItem.uid
+                const name = removedItem.name
                 server.patchCampaign(token, campaignId, current => {
-                    if (uidToRemove) {
-                        return { ...current, items: current.items.filter(item => item.uid !== uidToRemove) }
-                    }
-                    const i = current.items.findIndex(item => item.name === nameToRemove)
+                    if (uid) return { ...current, items: current.items.filter(item => item.uid !== uid) }
+                    const i = current.items.findIndex(item => item.name === name)
                     if (i === -1) return current
                     return { ...current, items: current.items.filter((_, idx) => idx !== i) }
                 }).then(patched => {
@@ -178,13 +196,75 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
         const sourceItems: SheetEquipment[] = (equipmentView.read(dragItem.container) ?? []).filter(Boolean)
         const dropped = sourceItems[dragItem.index]
         if (!dropped) return
+        if (dropped.stack && (dropped.count ?? 0) > 1) {
+            setPendingTransfer({
+                item: { ...dropped, uid: dropped.uid ?? uuidv4() },
+                direction: 'toCommunal',
+                sourceContainer: dragItem.container,
+                quantity: 1,
+            })
+            return
+        }
+        // Non-stackable: transfer immediately
         equipmentView.publish(dragItem.container, listUtil.delete(sourceItems, dragItem.index))
-        // Assign a uid if the item doesn't have one (came from local sheet which predates uid)
         const droppedCopy = { ...dropped, uid: dropped.uid ?? uuidv4() }
         applyPatch(
             { ...campaign, items: [...campaign.items, droppedCopy] },
             c => ({ ...c, items: [...c.items, droppedCopy] }),
         )
+    }
+
+    function confirmTransfer() {
+        if (!pendingTransfer || !campaign || !token) return
+        const { item, direction, sourceContainer, quantity } = pendingTransfer
+        setPendingTransfer(null)
+
+        if (direction === 'toCommunal') {
+            const sourceItems: SheetEquipment[] = (equipmentView.read(sourceContainer!) ?? []).filter(Boolean)
+            const srcIdx = sourceItems.findIndex(i => i.uid ? i.uid === item.uid : i.name === item.name)
+            if (srcIdx === -1) return
+            const src = sourceItems[srcIdx]
+            const remaining = (src.count ?? 0) - quantity
+            if (remaining <= 0) {
+                equipmentView.publish(sourceContainer!, listUtil.delete(sourceItems, srcIdx))
+            } else {
+                const updated = sourceItems.map((i, idx) => idx === srcIdx ? { ...i, count: remaining } : i)
+                equipmentView.publish(sourceContainer!, updated)
+            }
+            const communalItem: SheetEquipment = { ...item, count: quantity, uid: item.uid ?? uuidv4() }
+            applyPatch(
+                { ...campaign, items: [...campaign.items, communalItem] },
+                c => ({ ...c, items: [...c.items, communalItem] }),
+            )
+        } else {
+            // toLocal: decrement or remove from communal, add to local container
+            const uid = item.uid
+            const name = item.name
+            const remaining = (item.count ?? 0) - quantity
+            applyPatch(
+                {
+                    ...campaign,
+                    items: remaining <= 0
+                        ? campaign.items.filter(i => uid ? i.uid !== uid : i.name !== name)
+                        : campaign.items.map(i => (uid ? i.uid === uid : i.name === name) ? { ...i, count: remaining } : i),
+                },
+                c => {
+                    const idx = uid ? c.items.findIndex(i => i.uid === uid) : c.items.findIndex(i => i.name === name)
+                    if (idx === -1) return c
+                    const cur = c.items[idx]
+                    const rem = (cur.count ?? 0) - quantity
+                    if (rem <= 0) return { ...c, items: c.items.filter((_, i) => i !== idx) }
+                    return { ...c, items: c.items.map((i, n) => n === idx ? { ...i, count: rem } : i) }
+                },
+            )
+            // Add taken quantity to local container (first available personal container)
+            const destContainer = equipmentView.read('') != null
+                ? Object.keys(equipmentView.read('') ?? {}).find(k => k !== 'communal') ?? 'personal'
+                : 'personal'
+            const destItems: SheetEquipment[] = (equipmentView.read(destContainer) ?? []).filter(Boolean)
+            const takenItem: SheetEquipment = { ...item, count: quantity, uid: uuidv4() }
+            equipmentView.publish(destContainer, [...destItems, takenItem])
+        }
     }
 
     const title = campaign?.stashName?.trim() || 'Communal'
@@ -267,6 +347,41 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
                 equipment={modalOpen ? rules.equipment : []}
                 addEquipment={addItem}
             />
+
+            <ActionModal
+                open={!!pendingTransfer}
+                close={() => setPendingTransfer(null)}
+                title={pendingTransfer?.direction === 'toCommunal' ? 'Add to communal stash' : 'Take from communal stash'}
+                actions={[
+                    {
+                        name: 'Confirm',
+                        type: 'primary',
+                        callback: confirmTransfer,
+                        disabled: !pendingTransfer || pendingTransfer.quantity < 1 || pendingTransfer.quantity > (pendingTransfer.item.count ?? 0),
+                    }
+                ]}
+            >
+                {pendingTransfer && (
+                    <div className='flex flex-col gap-3 py-2'>
+                        <p className='text-sm'>{pendingTransfer.item.name} — {pendingTransfer.item.count ?? 0} available</p>
+                        <div className='flex items-center gap-3'>
+                            <label className='text-sm'>Quantity:</label>
+                            <input
+                                type='number'
+                                className='input input-bordered w-24'
+                                min={1}
+                                max={pendingTransfer.item.count ?? 1}
+                                value={pendingTransfer.quantity}
+                                onChange={e => setPendingTransfer({
+                                    ...pendingTransfer,
+                                    quantity: Math.max(1, Math.min(pendingTransfer.item.count ?? 1, parseInt(e.target.value) || 1))
+                                })}
+                            />
+                            <span className='text-sm opacity-60'>/ {pendingTransfer.item.count ?? 0}</span>
+                        </div>
+                    </div>
+                )}
+            </ActionModal>
         </DropTarget>
     )
 }

--- a/char-sheet/src/components/CampaignPanel.tsx
+++ b/char-sheet/src/components/CampaignPanel.tsx
@@ -30,6 +30,7 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
     const [modalOpen, setModalOpen] = useState(false)
     const [notFound, setNotFound] = useState(false)
     const selfWriting = useRef(false)
+    const metaRef = useRef<{ title: string, owner: string } | null>(null)
 
     const canEdit = !!(token && campaign)
 
@@ -43,7 +44,8 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
                     if (item?.content?.type === 'campaign') {
                         const c: Campaign = { ...item.content, members: item.content.members ?? [], items: item.content.items ?? [] }
                         setCampaign(c)
-                        setMeta({ title: item.title, owner: item.owner })
+                        metaRef.current = { title: item.title, owner: item.owner }
+                        setMeta(metaRef.current)
                         setNotFound(false)
                         selfWriting.current = true
                         equipmentView.publish('communal', c.items)
@@ -65,7 +67,7 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
                 if (!prev) return prev
                 const updated = { ...prev, items }
                 if (token) {
-                    server.writeCampaign(token, campaignId, meta?.title ?? '', updated)
+                    server.writeCampaign(token, campaignId, metaRef.current?.title ?? '', updated)
                         .catch(e => alertError(`Error syncing campaign: ${e.message}`))
                 }
                 return updated
@@ -94,7 +96,7 @@ function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
         selfWriting.current = true
         equipmentView.publish('communal', updated.items)
         if (token) {
-            server.writeCampaign(token, campaignId, meta?.title ?? '', updated)
+            server.writeCampaign(token, campaignId, metaRef.current?.title ?? '', updated)
                 .catch(e => alertError(`Error updating campaign: ${e.message}`))
         }
     }

--- a/char-sheet/src/components/CampaignPanel.tsx
+++ b/char-sheet/src/components/CampaignPanel.tsx
@@ -1,0 +1,214 @@
+// External imports
+import { useEffect, useRef, useState } from 'react'
+
+// Components
+import IconButton from './IconButton'
+import EquipmentSelectModal from './EquipmentSelectModal'
+import PointEntryBox from './PointEntryBox'
+import { DragSource } from './dnd/DragSource'
+import { DropTarget } from './dnd/DropTarget'
+
+// Internal imports
+import { Campaign, Equipment, Rules, SheetEquipment } from '../lib/rules'
+import server, { ServerItem } from '../lib/server'
+import { alertError } from '../lib/alerts'
+import { View } from '../lib/objectservice'
+import { listUtil } from '../lib/util'
+
+const POLL_INTERVAL_MS = 5000
+
+function CampaignPanel({ campaignId, sheetId, token, rules, equipmentView }: {
+    campaignId: string,
+    sheetId: string | null,
+    token: string | null,
+    rules: Rules,
+    equipmentView: View,
+}): JSX.Element {
+
+    const [campaign, setCampaign] = useState<Campaign | null>(null)
+    const [meta, setMeta] = useState<{ title: string, owner: string } | null>(null)
+    const [modalOpen, setModalOpen] = useState(false)
+    const [notFound, setNotFound] = useState(false)
+    const selfWriting = useRef(false)
+
+    const canEdit = !!(token && campaign)
+
+    useEffect(() => {
+        let cancelled = false
+
+        function refresh() {
+            server.read(campaignId)
+                .then((item: ServerItem) => {
+                    if (cancelled) return
+                    if (item?.content?.type === 'campaign') {
+                        const c: Campaign = { ...item.content, members: item.content.members ?? [], items: item.content.items ?? [] }
+                        setCampaign(c)
+                        setMeta({ title: item.title, owner: item.owner })
+                        setNotFound(false)
+                        selfWriting.current = true
+                        equipmentView.publish('communal', c.items)
+                    } else {
+                        setNotFound(true)
+                    }
+                })
+                .catch(() => {
+                    if (!cancelled) setNotFound(true)
+                })
+        }
+
+        // Watch for EquipmentTable dropping communal items into local containers
+        const unsub = equipmentView.view('communal').subscribe('', () => {
+            if (selfWriting.current) { selfWriting.current = false; return }
+            if (cancelled) return
+            const items: SheetEquipment[] = (equipmentView.read('communal') ?? []).filter(Boolean)
+            setCampaign(prev => {
+                if (!prev) return prev
+                const updated = { ...prev, items }
+                if (token) {
+                    server.writeCampaign(token, campaignId, meta?.title ?? '', updated)
+                        .catch(e => alertError(`Error syncing campaign: ${e.message}`))
+                }
+                return updated
+            })
+        })
+
+        refresh()
+        const id = setInterval(refresh, POLL_INTERVAL_MS)
+        return () => {
+            cancelled = true
+            clearInterval(id)
+            unsub()
+            equipmentView.delete('communal')
+        }
+    }, [campaignId])
+
+    function lookupDescription(name: string): string {
+        for (const e of rules.equipment) {
+            if (e.name === name) return e.description ?? name
+        }
+        return name
+    }
+
+    function saveUpdated(updated: Campaign) {
+        setCampaign(updated)
+        selfWriting.current = true
+        equipmentView.publish('communal', updated.items)
+        if (token) {
+            server.writeCampaign(token, campaignId, meta?.title ?? '', updated)
+                .catch(e => alertError(`Error updating campaign: ${e.message}`))
+        }
+    }
+
+    function addItem(equipment: Equipment) {
+        if (!campaign) return
+        const item: SheetEquipment = { name: equipment.name }
+        if (equipment.custom) item.custom = true
+        if (equipment.stack) { item.count = 1; item.stack = equipment.stack }
+        saveUpdated({ ...campaign, items: [...campaign.items, item] })
+    }
+
+    function removeItem(index: number) {
+        if (!campaign) return
+        saveUpdated({ ...campaign, items: campaign.items.filter((_, i) => i !== index) })
+    }
+
+    function setItemCount(index: number, count: number) {
+        if (!campaign) return
+        saveUpdated({ ...campaign, items: campaign.items.map((item, i) => i === index ? { ...item, count } : item) })
+    }
+
+    // Drop from local equipment container into communal
+    function onDropFromLocal(dragItem: { container: string, index: number }) {
+        if (!campaign) return
+        const sourceItems: SheetEquipment[] = (equipmentView.read(dragItem.container) ?? []).filter(Boolean)
+        const dropped = sourceItems[dragItem.index]
+        if (!dropped) return
+        equipmentView.publish(dragItem.container, listUtil.delete(sourceItems, dragItem.index))
+        saveUpdated({ ...campaign, items: [...campaign.items, { ...dropped }] })
+    }
+
+    const title = 'Communal'
+
+    if (notFound) {
+        return (
+            <table className="table table-compact w-80">
+                <thead><tr><th>Items: {title}</th></tr></thead>
+                <tbody><tr><td className='text-error'>Campaign not found.</td></tr></tbody>
+            </table>
+        )
+    }
+
+    if (!campaign) {
+        return (
+            <table className="table table-compact w-80">
+                <thead><tr><th>Items: {title}</th></tr></thead>
+                <tbody><tr><td>Loading...</td></tr></tbody>
+            </table>
+        )
+    }
+
+    return (
+        <DropTarget accept='equipment' enabled={canEdit} onDrop={onDropFromLocal}>
+            <table className="table table-compact w-80">
+                <thead>
+                    <tr><th colSpan={3}>Items: {title}</th></tr>
+                </thead>
+                <tbody>
+                    {campaign.items.map((item, i) => (
+                        <tr
+                            className='hover tooltip tooltip-left w-full'
+                            data-tip={lookupDescription(item.name)}
+                            key={i}
+                        >
+                            <td className='w-full text-left'>
+                                <DragSource type='communal' item={{ index: i }} enabled={canEdit}>
+                                    {item.name}
+                                </DragSource>
+                            </td>
+                            <td>
+                                <PointEntryBox
+                                    value={item.count ?? 0}
+                                    setValue={v => setItemCount(i, v)}
+                                    max={item.stack ?? 1}
+                                    visible={(item.stack ?? 1) > 1}
+                                    editable={canEdit}
+                                />
+                            </td>
+                            <td>
+                                <IconButton
+                                    icon='cross'
+                                    onClick={() => removeItem(i)}
+                                    btnStyle='btn-outline btn-error'
+                                    enabled={canEdit}
+                                />
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <th colSpan={3}>
+                            <div className='flex justify-center'>
+                                <IconButton
+                                    icon='plus'
+                                    enabled={canEdit}
+                                    onClick={() => setModalOpen(true)}
+                                />
+                            </div>
+                        </th>
+                    </tr>
+                </tfoot>
+            </table>
+
+            <EquipmentSelectModal
+                open={modalOpen}
+                close={() => setModalOpen(false)}
+                enabled={canEdit}
+                equipment={modalOpen ? rules.equipment : []}
+                addEquipment={addItem}
+            />
+        </DropTarget>
+    )
+}
+
+export default CampaignPanel

--- a/char-sheet/src/components/EquipmentTable.tsx
+++ b/char-sheet/src/components/EquipmentTable.tsx
@@ -20,9 +20,9 @@ function EquipmentTable({equipment, container, view, editable=EditMode.Live}: {
     equipment: Equipment[],
     container: Container,
     view: View,
-    editable?: EditMode
+    editable?: EditMode,
   }): JSX.Element {
-  
+
   const items: SheetEquipment[] = useListener(view) ?? []
   const freeCapacity = container.size ? (container.size - items.length) : 1
   const [modalOpen, setModalOpen] = useState(false)
@@ -51,26 +51,29 @@ function EquipmentTable({equipment, container, view, editable=EditMode.Live}: {
   }
 
   function onDropEquipment(item: any) {
-    const source = item.container
-    const index = item.index
+    const source: string = item.container ?? 'communal'
+    const index: number = item.index
     const dest = container.name
 
     const root = view.view("../")
 
-    const sourceItems = root.read(source)
-    const destItems = root.read(dest) ?? []
+    const sourceItems: SheetEquipment[] = (root.read(source) ?? []).filter(Boolean)
+    const destItems: SheetEquipment[] = (root.read(dest) ?? []).filter(Boolean)
+    const dragged = sourceItems[index]
 
-    if (sourceItems === destItems) {
+    if (!dragged) return
+
+    if (source === dest) {
       root.publish(source, listUtil.move(sourceItems, index, sourceItems.length-1))
     } else {
       root.publish(source, listUtil.delete(sourceItems, index))
-      root.publish(dest, listUtil.add(destItems, sourceItems[index]))
+      root.publish(dest, listUtil.add(destItems, dragged))
     }
   }
 
   return (
     <DropTarget
-      accept='equipment'
+      accept={['equipment', 'communal']}
       enabled={ editable >= EditMode.Live && freeCapacity > 0 }
       onDrop={onDropEquipment}
     >
@@ -83,6 +86,7 @@ function EquipmentTable({equipment, container, view, editable=EditMode.Live}: {
         <tbody>
         {
           items.map((item, i) => {
+            if (!item) return null
             return <tr className='hover tooltip tooltip-left w-full' data-tip={lookupDescription(item.name)} key={i}>
               {
                 editable >= EditMode.Full && item.custom ?

--- a/char-sheet/src/components/LoadSheetModal.tsx
+++ b/char-sheet/src/components/LoadSheetModal.tsx
@@ -45,11 +45,11 @@ function LoadSheetModal({open, close, setSheet, sheets, setSheets, token}:{
     {
       sheets == null ?
         <LoadingSpinner/> :
-      !sheets.length ?
+      !sheets.filter(s => s.content?.type !== 'campaign').length ?
         "No sheets found" :
       <div className='scrollbar scrollbar-neutral flex flex-col items-center gap-2 p-2'>
       {
-        sheets.map( s => 
+        sheets.filter(s => s.content?.type !== 'campaign').map( s =>
           <div className='flex flex-row gap-2 max-w-xl w-full' key={s.title}>
             <button
               className='btn btn-primary p-0 grow'

--- a/char-sheet/src/components/MenuRibbon.tsx
+++ b/char-sheet/src/components/MenuRibbon.tsx
@@ -4,15 +4,16 @@ import React, { useState } from 'react'
 // Components
 import NewSheetModal from './NewSheetModal';
 import LoadSheetModal from './LoadSheetModal'
+import CampaignModal from './CampaignModal'
 import { BsPerson, BsShare, BsCloudArrowDown,
   BsCloudArrowUp, BsFileEarmarkPlus, BsDownload,
-  BsJournalText, BsCopy,
+  BsJournalText, BsCopy, BsPeopleFill,
  } from 'react-icons/bs'
 import { ImCheckmark, ImPencil } from 'react-icons/im';
 
 // Internal imports
 import { downloadObject, copyToClipboard, EditMode } from '../lib/util'
-import { Sheet } from '../lib/rules'
+import { Rules, Sheet } from '../lib/rules'
 import server, { ServerItem } from '../lib/server'
 import UserLoginModal from './UserLoginModal';
 import { alertError, alertInfo, alertSuccess, alertWarning } from '../lib/alerts';
@@ -30,10 +31,21 @@ function MenuRibbon( {editable, setEditable, view, children}: {
   const [isNewSheetOpen, setIsNewSheetOpen] = useState(false)
   const [isLoginOpen, setIsLoginOpen] = useState(false)
   const [isLoadSheetOpen, setIsLoadSheetOpen] = useState(false)
+  const [isCampaignOpen, setIsCampaignOpen] = useState(false)
   const [sheetList, setSheetList] = useState(null as ServerItem[] | null)
 
   const token = useListener(view, "token")
   const sheetId = useListener(view, "sheet/id")
+  const activeCampaignId: string | null = useListener(view, "sheet/campaignId") ?? null
+  const rules: Rules = useListener(view, "rules")
+
+  function setActiveCampaignId(id: string | null) {
+    if (id) {
+      view.publish('sheet/campaignId', id)
+    } else {
+      view.delete('sheet/campaignId')
+    }
+  }
 
   function setSheet(sheet: Sheet | null) {
     if (sheet) {
@@ -139,6 +151,16 @@ function MenuRibbon( {editable, setEditable, view, children}: {
       Share
     </button>
   </li>,
+  <li key='campaign'>
+    <button
+      className={`btn btn-ghost ${activeCampaignId ? 'btn-active' : ''}`}
+      onClick={() => setIsCampaignOpen(true)}
+      disabled={!token}
+    >
+      <BsPeopleFill size={25}/>
+      Campaign
+    </button>
+  </li>,
   <li key='rules'>
   <button
     className='btn btn-ghost'
@@ -220,6 +242,15 @@ function MenuRibbon( {editable, setEditable, view, children}: {
       setSheets={setSheetList}
       sheets={sheetList}
       token={token}
+    /> : null }
+
+    { rules ? <CampaignModal
+      open={isCampaignOpen}
+      close={() => setIsCampaignOpen(false)}
+      token={token}
+      sheetId={sheetId ?? null}
+      rules={rules}
+      setActiveCampaignId={setActiveCampaignId}
     /> : null }
   </div>
   )

--- a/char-sheet/src/components/SheetView.tsx
+++ b/char-sheet/src/components/SheetView.tsx
@@ -8,6 +8,7 @@ import PowerTable from './PowerTable'
 import WoundTable from './WoundTable'
 import EquipmentTable from './EquipmentTable'
 import NotesTable from './NotesTable'
+import CampaignPanel from './CampaignPanel'
 
 // Internal imports
 import { View, useListener } from '../lib/objectservice'
@@ -21,14 +22,17 @@ import { Rules } from '../lib/rules'
  * Sheet view. Contains all other sheet displaying components.
  */
 
-function SheetView( { view, editable=EditMode.Live }: {
+function SheetView( { view, editable=EditMode.Live, campaignId=null, token=null }: {
     view: View,
-    editable?: EditMode
+    editable?: EditMode,
+    campaignId?: string | null,
+    token?: string | null,
   }): JSX.Element {
   
   // This will trigger a re-render if the level changes. This is probably fine.
   let level: number = useListener(view, 'sheet/info/level') ?? 0
   let rules: Rules = useListener(view, 'rules')
+  let sheetId: string | null = useListener(view, 'sheet/id') ?? null
 
   return (
     <div className='flex flex-wrap justify-center flex-row gap-4 basis-full p-4 scrollbar scrollbar-neutral'>
@@ -77,6 +81,15 @@ function SheetView( { view, editable=EditMode.Live }: {
           />
           } )
         }
+        {campaignId && (
+          <CampaignPanel
+            campaignId={campaignId}
+            sheetId={sheetId}
+            token={token}
+            rules={rules}
+            equipmentView={view.view('sheet/equipment')}
+          />
+        )}
         </section>
 
         {/* Powers & Wounds */}

--- a/char-sheet/src/components/dnd/DropTarget.tsx
+++ b/char-sheet/src/components/dnd/DropTarget.tsx
@@ -3,7 +3,7 @@ import { useDrop } from 'react-dnd';
 
 export function DropTarget({onDrop, accept = 'item', enabled = true, children}: {
   onDrop(item: any): void,
-  accept?: string,
+  accept?: string | string[],
   enabled?: boolean,
   children: ReactNode,
 }): JSX.Element  {

--- a/char-sheet/src/lib/rules.tsx
+++ b/char-sheet/src/lib/rules.tsx
@@ -76,6 +76,12 @@ export interface SheetEquipment {
     custom?: boolean,
 }
 
+export interface Campaign {
+    type: 'campaign',
+    members: string[],  // sheet IDs
+    items: SheetEquipment[],
+}
+
 export interface SheetWound {
     name?: string,
     size: number,
@@ -94,6 +100,7 @@ export interface Sheet {
     rules: string,
     id: string,
     owner: string | null,
+    campaignId?: string,
     info: SheetInfo,
     currency: Dictionary<number>,
     equipment: Dictionary<SheetEquipment[]>,

--- a/char-sheet/src/lib/rules.tsx
+++ b/char-sheet/src/lib/rules.tsx
@@ -79,6 +79,7 @@ export interface SheetEquipment {
 export interface Campaign {
     type: 'campaign',
     members: string[],  // sheet IDs
+    stashName?: string,
     items: SheetEquipment[],
 }
 

--- a/char-sheet/src/lib/rules.tsx
+++ b/char-sheet/src/lib/rules.tsx
@@ -71,6 +71,7 @@ export interface Rules {
 
 export interface SheetEquipment {
     name: string,
+    uid?: string,
     count?: number,
     stack?: number,
     custom?: boolean,

--- a/char-sheet/src/lib/server.tsx
+++ b/char-sheet/src/lib/server.tsx
@@ -69,8 +69,9 @@ async function deleteContent(token: string, id: string): Promise<ServerItem[]> {
     return result.list
 }
 
-async function listCampaigns(): Promise<ServerItem[]> {
+async function listCampaigns(token: string): Promise<ServerItem[]> {
     const result = await post({
+        token: token,
         listCampaigns: "*",
     })
     return result.listCampaigns ?? [];

--- a/char-sheet/src/lib/server.tsx
+++ b/char-sheet/src/lib/server.tsx
@@ -1,3 +1,5 @@
+import { Campaign } from './rules'
+
 const SERVER_URI = 'https://caltrops.tlembedded.com/api/'
 
 export interface ServerItem {
@@ -67,6 +69,29 @@ async function deleteContent(token: string, id: string): Promise<ServerItem[]> {
     return result.list
 }
 
+async function listCampaigns(): Promise<ServerItem[]> {
+    const result = await post({
+        listCampaigns: "*",
+    })
+    return result.listCampaigns ?? [];
+}
+
+async function writeCampaign(token: string, id: string, title: string, content: Campaign): Promise<boolean> {
+    await post({
+        token: token,
+        write: [{ id, title, content }]
+    })
+    return true;
+}
+
+async function joinCampaign(token: string, campaignId: string, sheetId: string): Promise<boolean> {
+    await post({
+        token: token,
+        joinCampaign: { campaignId, sheetId },
+    })
+    return true;
+}
+
 async function requestToken(email: string): Promise<boolean> {
     const result = await post({
         register: email
@@ -94,6 +119,9 @@ const server = {
     read: readContent,
     write: writeContent,
     delete: deleteContent,
+    listCampaigns: listCampaigns,
+    writeCampaign: writeCampaign,
+    joinCampaign: joinCampaign,
     parseToken: parseToken,
     requestToken: requestToken,
 }

--- a/char-sheet/src/lib/server.tsx
+++ b/char-sheet/src/lib/server.tsx
@@ -93,6 +93,25 @@ async function joinCampaign(token: string, campaignId: string, sheetId: string):
     return true;
 }
 
+async function patchCampaign(
+    token: string,
+    campaignId: string,
+    patch: (current: Campaign) => Campaign,
+): Promise<Campaign> {
+    const item = await readContent(campaignId)
+    if (!item || item.content?.type !== 'campaign') {
+        throw new Error('Campaign not found')
+    }
+    const current: Campaign = {
+        ...item.content,
+        members: item.content.members ?? [],
+        items: item.content.items ?? [],
+    }
+    const updated = patch(current)
+    await writeContent(token, campaignId, item.title, updated)
+    return updated
+}
+
 async function requestToken(email: string): Promise<boolean> {
     const result = await post({
         register: email
@@ -123,6 +142,7 @@ const server = {
     listCampaigns: listCampaigns,
     writeCampaign: writeCampaign,
     joinCampaign: joinCampaign,
+    patchCampaign: patchCampaign,
     parseToken: parseToken,
     requestToken: requestToken,
 }

--- a/char-sheet/src/pages/MainPage.tsx
+++ b/char-sheet/src/pages/MainPage.tsx
@@ -29,12 +29,16 @@ let SAVE_TIMEOUT_ID: any = -1
 function MainPage(): JSX.Element {
 
   function loadToken(): string | null {
-    let token = new URLSearchParams(window.location.search).get("token")
+    const params = new URLSearchParams(window.location.search)
+    let token = params.get("token")
     if (token && server.parseToken(token)) {
-      // Token supplied via URI. Save it.
       localStorage.setItem('caltrops-token', token)
-      // Reload without query params
-      window.location.href = window.location.href.split('?')[0]
+      // Preserve ?campaign= if present so loadSheet can pick it up
+      const campaignParam = params.get("campaign")
+      const next = campaignParam
+        ? `${window.location.pathname}?campaign=${encodeURIComponent(campaignParam)}`
+        : window.location.pathname
+      window.location.href = window.location.origin + next
     }
     else {
       token = localStorage.getItem('caltrops-token');
@@ -78,27 +82,35 @@ function MainPage(): JSX.Element {
       server.read(sheet_id).then(sheet => {
           const imported = caltrops.importSheet(sheet.content)
           view.publish("sheet", imported)
-
-          const pendingCampaign = sessionStorage.getItem('caltrops-pending-campaign')
-          if (pendingCampaign) {
-            sessionStorage.removeItem('caltrops-pending-campaign')
-            const token = view.read('token')
-            if (token && imported.id) {
-              server.joinCampaign(token, pendingCampaign, imported.id)
-                .then(() => {
-                  view.publish('sheet/campaignId', pendingCampaign)
-                  alertSuccess('Joined campaign')
-                })
-                .catch(e => alertError(`Error joining campaign: ${e.message}`))
-            } else {
-              alertWarning('Log in and load a character sheet to join the campaign.')
-            }
-          }
+          tryJoinPendingCampaign(view, imported.id)
         }
       ).catch(e => alertError(`Error reading sheet: ${e.message}`))
       return null;
     }
+
+    // No saved sheet — warn if an invite link was followed
+    if (sessionStorage.getItem('caltrops-pending-campaign')) {
+      alertWarning('Open your character sheet first, then follow the campaign invite link.')
+    }
+
     return caltrops.newSheet(view.read('rules'))
+  }
+
+  function tryJoinPendingCampaign(view: View, sheetId: string) {
+    const pendingCampaign = sessionStorage.getItem('caltrops-pending-campaign')
+    if (!pendingCampaign) return
+    sessionStorage.removeItem('caltrops-pending-campaign')
+    const token = view.read('token')
+    if (!token) {
+      alertWarning('Log in to join the campaign.')
+      return
+    }
+    server.joinCampaign(token, pendingCampaign, sheetId)
+      .then(() => {
+        view.publish('sheet/campaignId', pendingCampaign)
+        alertSuccess('Joined campaign')
+      })
+      .catch(e => alertError(`Error joining campaign: ${e.message}`))
   }
 
   function setTitle(title: string | undefined) {

--- a/char-sheet/src/pages/MainPage.tsx
+++ b/char-sheet/src/pages/MainPage.tsx
@@ -164,6 +164,8 @@ function MainPage(): JSX.Element {
   })
 
   const sheetId = useListener(view, "sheet/id")
+  const token = useListener(view, "token")
+  const activeCampaignId: string | null = useListener(view, "sheet/campaignId") ?? null
 
   return (
     <FileUploader setFile={s => view.publish("sheet", s)}>
@@ -178,6 +180,8 @@ function MainPage(): JSX.Element {
           <SheetView
             view={view}
             editable={editable}
+            campaignId={activeCampaignId}
+            token={token}
           /> :
           <LoadingSpinner size={100}/>
         }

--- a/char-sheet/src/pages/MainPage.tsx
+++ b/char-sheet/src/pages/MainPage.tsx
@@ -60,13 +60,40 @@ function MainPage(): JSX.Element {
   }
 
   function loadSheet(view: View): Sheet | null {
-    let sheet_id = new URLSearchParams(window.location.search).get("sheet")
+    const params = new URLSearchParams(window.location.search)
+    let sheet_id = params.get("sheet")
     if (!sheet_id) {
       sheet_id = localStorage.getItem('caltrops-sheet')
     }
+
+    const campaignParam = params.get("campaign")
+    if (campaignParam) {
+      // Store pending campaign join; handled after sheet loads
+      sessionStorage.setItem('caltrops-pending-campaign', campaignParam)
+      // Strip query params without full reload
+      window.history.replaceState({}, '', window.location.pathname)
+    }
+
     if (sheet_id) {
-      server.read(sheet_id).then( sheet => {
-          view.publish("sheet", caltrops.importSheet(sheet.content))
+      server.read(sheet_id).then(sheet => {
+          const imported = caltrops.importSheet(sheet.content)
+          view.publish("sheet", imported)
+
+          const pendingCampaign = sessionStorage.getItem('caltrops-pending-campaign')
+          if (pendingCampaign) {
+            sessionStorage.removeItem('caltrops-pending-campaign')
+            const token = view.read('token')
+            if (token && imported.id) {
+              server.joinCampaign(token, pendingCampaign, imported.id)
+                .then(() => {
+                  view.publish('sheet/campaignId', pendingCampaign)
+                  alertSuccess('Joined campaign')
+                })
+                .catch(e => alertError(`Error joining campaign: ${e.message}`))
+            } else {
+              alertWarning('Log in and load a character sheet to join the campaign.')
+            }
+          }
         }
       ).catch(e => alertError(`Error reading sheet: ${e.message}`))
       return null;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -89,13 +89,21 @@ async function listContent(user) {
     }).promise()).Items;
 }
 
-async function listAllCampaigns() {
-    return (await db.scan({
+async function listAccessibleCampaigns(user) {
+    const owned = await listContent(user)
+    const ownedCampaigns = owned.filter(i => i.content?.type === 'campaign')
+    const memberCampaigns = (await db.scan({
         TableName: TABLE_NAME,
-        FilterExpression: "content.#t = :campaign",
+        FilterExpression: "content.#t = :campaign AND contains(content.members, :user)",
         ExpressionAttributeNames: { "#t": "type" },
-        ExpressionAttributeValues: { ":campaign": "campaign" },
+        ExpressionAttributeValues: { ":campaign": "campaign", ":user": user },
     }).promise()).Items;
+    const seen = new Set()
+    return [...ownedCampaigns, ...memberCampaigns].filter(c => {
+        if (seen.has(c.id)) return false
+        seen.add(c.id)
+        return true
+    })
 }
 
 async function readContent(uid) {
@@ -243,8 +251,11 @@ exports.handler = async (event) => {
     }
 
     if (body.listCampaigns) {
+        if (!token) {
+            return errorResponse(401, "Unauthorised");
+        }
         try {
-            const all = await listAllCampaigns();
+            const all = await listAccessibleCampaigns(token.user);
             reply.listCampaigns = all.sort((a, b) => b.time.localeCompare(a.time));
         } catch (error) {
             return errorResponse(500, "Error listing campaigns", error);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -17,10 +17,10 @@ const OPTIONS_HEADERS = {
     "Access-Control-Allow-Headers": "*",
 };
 
-async function writeContent(uid, title, user, content) {
+async function writeContent(uid, title, user, content, existingOwner) {
     const item = {
         "id": uid,
-        "owner": user,
+        "owner": existingOwner ?? user,
         "title": title,
         "content": content,
         "time": (new Date()).toISOString()
@@ -49,7 +49,12 @@ async function canDelete(token, uid) {
 async function canWrite(token, uid) {
     if (!token) { return false; }
     let item = await readContent(uid);
-    return (item === null) || (item.owner === token.user);
+    if (item === null) { return true; }
+    if (item.owner === token.user) { return true; }
+    if (item.content?.type === 'campaign' &&
+        Array.isArray(item.content.members) &&
+        item.content.members.includes(token.user)) { return true; }
+    return false;
 }
 
 function canSign(token) {
@@ -81,6 +86,15 @@ async function listContent(user) {
             "#o": "owner"
         },
         Select: "ALL_PROJECTED_ATTRIBUTES"
+    }).promise()).Items;
+}
+
+async function listAllCampaigns() {
+    return (await db.scan({
+        TableName: TABLE_NAME,
+        FilterExpression: "content.#t = :campaign",
+        ExpressionAttributeNames: { "#t": "type" },
+        ExpressionAttributeValues: { ":campaign": "campaign" },
     }).promise()).Items;
 }
 
@@ -171,10 +185,18 @@ exports.handler = async (event) => {
     if (body.write) {
         try {
             for (const info of body.write) {
-                if (await canWrite(token, info.id)) {
-                    await writeContent(info.id, info.title, token.user, info.content);
+                const existing = await readContent(info.id);
+                if (existing !== null && existing.owner !== token?.user) {
+                    // Campaign member write — validate access then preserve original owner
+                    if (!await canWrite(token, info.id)) {
+                        return errorResponse(401, "Unauthorised");
+                    }
+                    await writeContent(info.id, info.title, token.user, info.content, existing.owner);
                 } else {
-                    return errorResponse(401, "Unauthorised");
+                    if (!await canWrite(token, info.id)) {
+                        return errorResponse(401, "Unauthorised");
+                    }
+                    await writeContent(info.id, info.title, token.user, info.content);
                 }
             }
         } catch (error) {
@@ -217,6 +239,37 @@ exports.handler = async (event) => {
             reply.list = items.sort( (a,b) => b.time.localeCompare(a.time) );
         } catch (error) {
             return errorResponse(500, "Error listing content", error);
+        }
+    }
+
+    if (body.listCampaigns) {
+        try {
+            const all = await listAllCampaigns();
+            reply.listCampaigns = all.sort((a, b) => b.time.localeCompare(a.time));
+        } catch (error) {
+            return errorResponse(500, "Error listing campaigns", error);
+        }
+    }
+
+    if (body.joinCampaign) {
+        if (!token) {
+            return errorResponse(401, "Unauthorised");
+        }
+        try {
+            const { campaignId, sheetId } = body.joinCampaign;
+            const existing = await readContent(campaignId);
+            if (!existing || existing.content?.type !== 'campaign') {
+                return errorResponse(404, "Campaign not found");
+            }
+            const members = existing.content.members ?? [];
+            if (!members.includes(sheetId)) {
+                members.push(sheetId);
+            }
+            const updated = { ...existing.content, members };
+            await writeContent(campaignId, existing.title, existing.owner, updated, existing.owner);
+            reply.joinCampaign = true;
+        } catch (error) {
+            return errorResponse(500, "Error joining campaign", error);
         }
     }
 


### PR DESCRIPTION
# Communal Items Panel

Adds a campaign system with a shared item stash accessible to all members.

## Features

- DMs can create a campaign with a name and optional stash name via the Campaign modal
- Players browse all campaigns and join with a single click — membership is stored on their character sheet
- Joined characters see a communal "Items: Communal" panel in their equipment column, consistent with existing item tables
- The panel polls for updates every 5 seconds so all players see changes in near real-time
- Items can be added/removed via the + button or dragged between the communal stash and personal containers
- Doubles as a trade window — drag an item into the communal stash for another player to pick up
- Leaving a campaign removes the panel from the character sheet

## Server changes

- New listCampaigns handler — scans for all campaign-type documents (no auth required)
- New joinCampaign handler — appends a sheet ID to a campaign's member list
- writeContent updated to preserve original owner when campaign members write to a shared document
- Campaigns are stored in the existing DynamoDB table as documents with content.type === 'campaign'
Notes

 - listCampaigns uses a full table scan — acceptable for the current userbase, can be optimised with a GSI if needed
Requires Lambda deployment to function — frontend is complete and tested against mock data